### PR TITLE
Create autoresponder for pausing community contributions

### DIFF
--- a/.github/workflows/pause-community-contributions.yml
+++ b/.github/workflows/pause-community-contributions.yml
@@ -15,6 +15,8 @@ jobs:
     name: Pause Community Contributions
     runs-on: ubuntu-latest
     steps:
+      - name: The Event
+        run: echo "${{ github.event_name }}"
       - name: Detect if user is org member
         uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
         id: is-organization-member

--- a/.github/workflows/pause-community-contributions.yml
+++ b/.github/workflows/pause-community-contributions.yml
@@ -1,0 +1,53 @@
+name: Pause Community Contributions
+
+on:
+  push:
+  issues:
+    types:
+      - opened
+  pull_request_target:
+    types:
+      - opened
+  workflow_dispatch:
+
+jobs:
+  pause:
+    name: Pause Community Contributions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect if user is org member
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        id: is-organization-member
+        with:
+          script: |
+            if (context.actor == 'dependabot' || context.actor == 'exercism-bot' || context.actor == 'github-actions[bot]') {
+              return false;
+            }
+
+            return github.rest.orgs.checkMembershipForUser({
+              org: "exercism",
+              username: context.actor,
+            }).then(response => response.status == 204)
+              .catch(err => false);
+      - name: Comment
+        if: steps.is-organization-member.outputs.result == 'false'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Hello. Thanks for opening an issue/PR on Exercism. We are currently in a phase of our journey where we have paused community contributions to allow us to take a breather and redesign our community model. You can learn more in [this blog post](https://exercism.org/blog/TODO).\n\n**As such, all issues and PRs in this repository are being automatically closed.**\n\nThat doesn’t mean we’re not interested in your ideas. If you’re stuck on something we still want to help. The best place to discuss things is with our community on [the forum](https://forum.exercism.org/c/support/8), so please feel free to copy this into a new topic there.\n\n---\n\n_Note: If you’ve had this issue/PR pre-approved on the forum, please link back to this issue/PR on the forum and a maintainer or @jonathandmiddleton will reopen it._\n"
+            })
+      - name: Close
+        if: steps.is-organization-member.outputs.result == 'false'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              state: "closed",
+            })


### PR DESCRIPTION
We're going to take a step back and redesign the volunteering model for Exercism.
Please see this blog post for context:
BLOG_POST_URL

As part of this, we recommend that you add the `paused` label to all open issues and PRs unless they are in-progress or you plan to work on them in the short-term.
All `paused` issues and PRs can then be bulk-closed, and can be reopened when they are ready to be worked on.

This PR will be auto-merged on Friday November 25th, 2022.
If, as a maintainer of this repository, you wish to continue to accept community contributions,
then you will need to reach out to Jeremy to discuss this, as mentioned in the blog post.
