### PR TITLE
Create autoresponder for pausing community contributions

### DIFF
--- a/.github/workflows/pause-community-contributions.yml
+++ b/.github/workflows/pause-community-contributions.yml
@@ -1,13 +1,15 @@
 name: Pause Community Contributions
 
 on:
-  push:
   issues:
     types:
       - opened
   pull_request_target:
     types:
       - opened
+    paths-ignore:
+      - "exercises/*/*/.approaches/**"
+      - "exercises/*/*/.articles/**"
   workflow_dispatch:
 
 jobs:
@@ -40,7 +42,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `ISSUE_COMMENT_BODY`
+              body: `"Hello. Thanks for opening ${aThing} on Exercism. We are currently in a phase of our journey where we have paused community contributions to allow us to take a breather and redesign our community model. You can learn more in [this blog post](https://exercism.org/blog/freeing-our-maintainers).\n\n**As such, all issues and PRs in this repository are being automatically closed.**\n\nThat doesn’t mean we’re not interested in your ideas. If you’re stuck on something we still want to help. The best place to discuss things is with our community on [the forum](https://forum.exercism.org/c/support/8), so please feel free to copy this into a new topic there.\n\n---\n\n_Note: If this ${thing} has been pre-approved, please link back to this ${thing} on the forum thread and a maintainer or @jonathandmiddleton will reopen it._\n"`
             })
       - name: Close
         if: steps.is-organization-member.outputs.result == 'false'


### PR DESCRIPTION
We're going to take a step back and redesign the volunteering model for Exercism.
Please see this blog post for context:
https://exercism.org/blog/freeing-our-maintainers

This PR adds an autoresponder that runs when an issue or PR is opened.
If the person opening the issue is not a member of the Exercism organization, the autoresponder posts a comment and closes the issue.
In the comment the author is directed to discuss the issue in the forum.

If the discussion in the forum results in the issue/PR being approved, a maintainer or Jonathan will reopen it.

This PR will be merged on Thursday December 1st, 2022.
