### PR TITLE
Create autoresponder for pausing community contributions

### DIFF
--- a/.github/workflows/pause-community-contributions.yml
+++ b/.github/workflows/pause-community-contributions.yml
@@ -1,7 +1,6 @@
 name: Pause Community Contributions
 
 on:
-  push:
   issues:
     types:
       - opened
@@ -13,7 +12,7 @@ on:
 jobs:
   pause:
     name: Pause Community Contributions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Detect if user is org member
         uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
@@ -25,7 +24,7 @@ jobs:
             }
 
             return github.rest.orgs.checkMembershipForUser({
-              org: "exercism",
+              org: context.repo.owner,
               username: context.actor,
             }).then(response => response.status == 204)
               .catch(err => false);
@@ -34,13 +33,15 @@ jobs:
         uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
         with:
           script: |
-            var thing = (context.eventName == 'issues' ? 'issue' : 'PR');
-            var aThing = (context.eventName == 'issues' ? 'an issue' : 'a PR');
+            const isIssue = !!context.payload.issue;
+            const subject = context.payload.issue || context.payload.pull_request;
+            const thing = (isIssue ? 'issue' : 'PR');
+            const aThing = (isIssue ? 'an issue' : 'a PR');
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `ISSUE_COMMENT_BODY`
+              body: `Hello. Thanks for opening ${aThing} on Exercism. We are currently in a phase of our journey where we have paused community contributions to allow us to take a breather and redesign our community model. You can learn more in [this blog post](https://exercism.org/blog/freeing-our-maintainers). **As such, all issues and PRs in this repository are being automatically closed.**\n\nThat doesn’t mean we’re not interested in your ideas, or that if you’re stuck on something we don’t want to help. The best place to discuss things is with our community on [the forum](https://forum.exercism.org/new-topic?title=${encodeURI(subject.title)}&body=${encodeURI(subject.body)}&category=support), so please feel free to copy this into a new topic there.\n\n---\n\n_Note: If this ${thing} has been pre-approved, please link back to this ${thing} on the forum thread and a maintainer or staff member will reopen it._\n`
             })
       - name: Close
         if: steps.is-organization-member.outputs.result == 'false'


### PR DESCRIPTION
We're going to take a step back and redesign the volunteering model for Exercism.
Please see [this blog post](https://exercism.org/blog/freeing-our-maintainers) for context.

This PR adds an autoresponder that runs when an issue or PR is opened. If the person opening the issue is not a member of the Exercism organization, the autoresponder posts a comment and closes the issue. In the comment the author is directed to discuss the issue in the forum.

If the discussion in the forum results in the issue/PR being approved, a maintainer or staff member will reopen it.

Please feel free to merge this PR. It will automatically be merged on December 1st, 2022. Please do not close it.

If you wish to discuss this, please do so in [this forum post](TODO) rather than here.
